### PR TITLE
Update Capfile

### DIFF
--- a/Capfile
+++ b/Capfile
@@ -1,5 +1,7 @@
 require "capistrano/setup"
 require "capistrano/deploy"
+require 'capistrano/scm/git'
+install_plugin Capistrano::SCM::Git
 
 require 'capistrano/rbenv'
 require 'capistrano/bundler'


### PR DESCRIPTION
fix "[capistrano] Future versions of Capistrano will not load the Git SCM plugin by default"対応